### PR TITLE
Only "hardcode" `OAuthImplicitRequest.state` if it was not provided through the config.

### DIFF
--- a/src/refresh.js
+++ b/src/refresh.js
@@ -3,9 +3,7 @@ import {assertPresent} from './util';
 class RefreshRequest {
     constructor(config) {
         assertPresent(config, ['refresh_token']);
-        this.grant_type = config.grant_type !== undefined
-          ? config.grant_type
-          : 'refresh_token';
+        this.grant_type = 'refresh_token';
         this.refresh_token = config.refresh_token;
         this.scope = config.scope;
     }

--- a/src/refresh.js
+++ b/src/refresh.js
@@ -3,7 +3,9 @@ import {assertPresent} from './util';
 class RefreshRequest {
     constructor(config) {
         assertPresent(config, ['refresh_token']);
-        this.grant_type = 'refresh_token';
+        this.grant_type = config.grant_type !== undefined
+          ? config.grant_type
+          : 'refresh_token';
         this.refresh_token = config.refresh_token;
         this.scope = config.scope;
     }

--- a/src/request.js
+++ b/src/request.js
@@ -22,9 +22,7 @@ class OAuthRequest {
 
 class OAuthImplicitRequest extends OAuthRequest {
     constructor(config) {
-        config.response_type = config.response_type !== undefined
-          ? config.response_type
-          : 'token';
+        config.response_type = 'token';
         super(config);
         assertPresent(config, ['client_id']);
         this.client_id = config.client_id;

--- a/src/request.js
+++ b/src/request.js
@@ -22,12 +22,16 @@ class OAuthRequest {
 
 class OAuthImplicitRequest extends OAuthRequest {
     constructor(config) {
-        config.response_type = 'token';
+        config.response_type = config.response_type !== undefined
+          ? config.response_type
+          : 'token';
         super(config);
         assertPresent(config, ['client_id']);
         this.client_id = config.client_id;
         this.redirect_uri = config.redirect_uri;
-        this.state = uuid.v4();
+        this.state = config.state !== undefined
+          ? config.state
+          : uuid.v4();
     }
 }
 


### PR DESCRIPTION
There's no reason to simply ignore a value that was set through the config array. If the developer wants to use a specific value (for example, for a non-compliant API), that value should not be silently overridden.

Fixes #13