### PR TITLE
Type declaration to not require optional parameters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,12 +20,12 @@ declare class RefreshRequest {
 }
 
 declare interface IOAuthRequest {
-    response_type: string;
-    scope: string;
-    metadata: object;
+    response_type?: string;
+    scope?: string;
+    metadata?: object;
 }
 
-declare class OAuthRequest implements IOAuthRequest {
+declare class OAuthRequest {
     response_type: string;
     scope: string;
     metadata: object;
@@ -35,7 +35,7 @@ declare class OAuthRequest implements IOAuthRequest {
 declare interface IOAuthImplicitRequest extends IOAuthRequest {
     client_id: string;
     redirect_uri: string;
-    state: string;
+    state?: string;
 }
 
 declare class OAuthImplicitRequest extends OAuthRequest implements IOAuthImplicitRequest {
@@ -95,10 +95,10 @@ declare class LocalTokenStorage extends OAuthTokenStorage {
 declare interface IProvider {
     id: string;
     authorization_url: string;
-    storage: WindowLocalStorage;
+    storage?: WindowLocalStorage;
 }
 
-declare class Provider implements IProvider {
+declare class Provider {
     id: string;
     authorization_url: string;
     storage: WindowLocalStorage;


### PR DESCRIPTION
The current type declaration requires that all properties are supplied when creating a new `Provider` or `Request` object, when the code supplies default values in the constructor.

See:

- https://github.com/zalando-stups/oauth2-client-js/blob/master/src/request.js#L17
- https://github.com/zalando-stups/oauth2-client-js/blob/master/src/request.js#L30
- https://github.com/zalando-stups/oauth2-client-js/blob/master/src/provider.js#L13

This PR flags the non-required parameters as optional so that using the default values passes type-checking. Without this change, the main example in the README has TS errors.